### PR TITLE
make passout year optional

### DIFF
--- a/prisma/migrations/20250727111821_passoutyear_optional/migration.sql
+++ b/prisma/migrations/20250727111821_passoutyear_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Member" ALTER COLUMN "passoutYear" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,7 +26,7 @@ model Member {
   leetcode      String?
   codechef      String?
   codeforces    String?
-  passoutYear   DateTime
+  passoutYear   DateTime?
   isApproved    Boolean  @default(false)
   isManager     Boolean  @default(false)
   createdAt     DateTime @default(now())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Passout Year" field for members is now optional, allowing you to leave it blank when adding or editing member information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->