### PR TITLE
Fixing typo in documentation

### DIFF
--- a/src/routes/members.ts
+++ b/src/routes/members.ts
@@ -85,7 +85,7 @@ export default function membersRouter(
    *   -F "name=John Doe" \
    *   -F "password=securePass123" \
    *   -F "passoutYear=2026" \
-   *   -F "provider=local" \
+   *   -F "provider=credentials" \
    *   http://localhost:3000/members
    */
   router.post("/", upload.single("file"), memberCtrl.createAMember(supabase));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated POST /members API example to use provider value “credentials” (replacing “local”), aligning with current authentication terminology.
  * Clarifies expected request payload for client integrations to reduce confusion.
  * No functional changes; request/response behavior remains unchanged.
  * Minor formatting cleanup at end of file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->