### PR TITLE
refactor image update logic in uploadImg function

### DIFF
--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -37,13 +37,11 @@ export async function uploadImage(
   }
   const ext = mime.split("/")[1];
 
-  let filename: string;
+  
   if (fileUrl) {
-    const { fileName } = extractFilePathAndNameFromUrl(fileUrl);
-    filename = fileName;
-  } else {
-    filename = `${uuidv4()}.${ext}`;
+    await deleteImage(supabase,fileUrl);
   }
+  const filename:string =  `${uuidv4()}.${ext}`;
 
   const filePath = `${folder}/${filename}`;
 

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -37,10 +37,6 @@ export async function uploadImage(
   }
   const ext = mime.split("/")[1];
 
-  
-  if (fileUrl) {
-    await deleteImage(supabase,fileUrl);
-  }
   const filename:string =  `${uuidv4()}.${ext}`;
 
   const filePath = `${folder}/${filename}`;
@@ -62,6 +58,10 @@ export async function uploadImage(
 
   if (!urlData?.publicUrl) {
     throw new ApiError("Failed to get public URL", 500);
+  }
+
+  if (fileUrl) {
+    await deleteImage(supabase, fileUrl);
   }
 
   return urlData.publicUrl;

--- a/tests/imageUtils.test.ts
+++ b/tests/imageUtils.test.ts
@@ -2,6 +2,7 @@ import { uploadImage, deleteImage } from "../src/utils/imageUtils";
 import { SupabaseClient, PostgrestError } from "@supabase/supabase-js";
 import { ApiError } from "../src/utils/apiError";
 import { v4 as uuidv4 } from "uuid";
+import { error } from "console";
 
 jest.mock("uuid");
 const mockedUuid = uuidv4 as jest.Mock;
@@ -21,6 +22,7 @@ describe("imageUtils", () => {
       from: jest.fn().mockReturnThis(),
       upload: jest.fn(),
       getPublicUrl: jest.fn(),
+      deleteImage: jest.fn(), 
       remove: jest.fn(),
     };
 
@@ -61,6 +63,7 @@ describe("imageUtils", () => {
       storageMock.getPublicUrl.mockReturnValue({
         data: { publicUrl: "https://public.url/existing.png" },
       });
+      storageMock.remove.mockReturnValue({error:null});
 
       const url = await uploadImage(
         mockSupabase as SupabaseClient,
@@ -70,7 +73,7 @@ describe("imageUtils", () => {
       );
       // Should use filename 'existing.png' instead of generating with uuid
       expect(storageMock.upload).toHaveBeenCalledWith(
-        "folder/existing.png",
+        "folder/test-uuid.png",
         dummyFile.buffer,
         { contentType: dummyFile.mimetype, upsert: true },
       );

--- a/tests/imageUtils.test.ts
+++ b/tests/imageUtils.test.ts
@@ -2,7 +2,6 @@ import { uploadImage, deleteImage } from "../src/utils/imageUtils";
 import { SupabaseClient, PostgrestError } from "@supabase/supabase-js";
 import { ApiError } from "../src/utils/apiError";
 import { v4 as uuidv4 } from "uuid";
-import { error } from "console";
 
 jest.mock("uuid");
 const mockedUuid = uuidv4 as jest.Mock;
@@ -21,8 +20,7 @@ describe("imageUtils", () => {
     storageMock = {
       from: jest.fn().mockReturnThis(),
       upload: jest.fn(),
-      getPublicUrl: jest.fn(),
-      deleteImage: jest.fn(), 
+      getPublicUrl: jest.fn(), 
       remove: jest.fn(),
     };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replacing an existing image now removes the old file and always generates a new unique filename to avoid conflicts.

* **Tests**
  * Updated tests to verify the removal of replaced images and the new unique-filename upload behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->